### PR TITLE
Add missing `filename` needed for include and extend

### DIFF
--- a/lib/jade2js.js
+++ b/lib/jade2js.js
@@ -37,7 +37,7 @@ var createJade2JsPreprocessor = function(logger, basePath, config) {
     log.debug('Processing "%s".', file.originalPath);
 
     try {
-       processed = jade.compile(content);
+       processed = jade.compile(content, {filename: file.originalPath});
     } catch (e) {
      log.error('%s\n  at %s', e.message, file.originalPath);
     }


### PR DESCRIPTION
Fix problem with `jade.compile` not getting `filename` option, which breaks parsing `include` and `extend` in JADE templates by not finding dirname of parsed file for relative paths.
