### PR TITLE
templateExtension configuration option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ module.exports = function(config) {
         return cacheId;
       },
 
+      // By default, Jade files are added to template cache with '.html' extension.
+      // Set this option to change it.
+      templateExtension: 'htm',
+
       // setting this option will create only a single module that contains templates
       // from all the files, so you can load them all with module('foo')
       moduleName: 'foo'

--- a/lib/jade2js.js
+++ b/lib/jade2js.js
@@ -25,6 +25,7 @@ var createJade2JsPreprocessor = function(logger, basePath, config) {
 
   var log = logger.create('preprocessor.jade2js');
   var moduleName = config.moduleName;
+  var templateExtension = config.templateExtension || 'html';
   var stripPrefix = new RegExp('^' + (config.stripPrefix || ''));
   var prependPrefix = config.prependPrefix || '';
   var cacheIdFromPath = config && config.cacheIdFromPath || function(filepath) {
@@ -33,7 +34,7 @@ var createJade2JsPreprocessor = function(logger, basePath, config) {
 
   return function(content, file, done) {
     var processed;
-    
+
     log.debug('Processing "%s".', file.originalPath);
 
     try {
@@ -44,7 +45,8 @@ var createJade2JsPreprocessor = function(logger, basePath, config) {
 
     content = processed();
 
-    var htmlPath = cacheIdFromPath(file.originalPath.replace(basePath + '/', '')).replace(/\.jade$/, '.html');
+    var htmlPath = cacheIdFromPath(file.originalPath.replace(basePath + '/', ''))
+                                                    .replace(/\.jade$/, '.' + templateExtension);
 
     file.path = file.path.replace(/\.jade$/, '.html') + '.js';
 


### PR DESCRIPTION
As agreed, this changes won't break public API and by default (i.e. when `templateExtension` option is not specified in karma config) library will behave exactly as it used to.

Here is how I use it myself:

```
    ngJade2JsPreprocessor: {
      stripPrefix: '.*/source-path',
      templateExtension: 'jade',
      moduleName: 'templates'
    },
```

I used `templateExtension` instead of `keepOriginalExtension` (boolean), because it gives more flexibility to users.
