### PR TITLE
stop the process when `processed` fails

### DIFF
--- a/lib/jade2js.js
+++ b/lib/jade2js.js
@@ -48,6 +48,7 @@ var createJade2JsPreprocessor = function(logger, basePath, config) {
        processed = jade.compile(content, jadeOptions);
     } catch (e) {
      log.error('%s\n  at %s', e.message, file.originalPath);
+     return;
     }
 
     content = processed(locals);


### PR DESCRIPTION
If `jade.compile` failed, processed would still be undefined and
so the whole thing would error out when trying to use an
undefined function
